### PR TITLE
added missing await

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ const full = async function (a, b, conflicts, unified) {
   await Promise.all([spoolchanges(a, aunsorted, conflicts), spoolchanges(b, bunsorted, conflicts)])
   console.error('sorting...')
   await sort(aunsorted, asorted)
-  sort(bunsorted, bsorted)
+  await sort(bunsorted, bsorted)
   console.log('calculating difference...')
   return await diff(asorted, bsorted, unified)
 }


### PR DESCRIPTION
This pull request addresses a critical issue where an `await` keyword was inadvertently omitted. This omission led to a situation where the first sorted list was occasionally compared against an empty list. This occurred because the asynchronous `sort()` promise was not consistently resolved prior to the invocation of the `diff` function. By introducing the necessary `await`, we ensure that the sorted list is retrieved before any comparisons are made, thereby comparing two correct items.